### PR TITLE
Fixed 8Dock not deleting top-most item when dragged into trash

### DIFF
--- a/src/TrashView.cpp
+++ b/src/TrashView.cpp
@@ -199,7 +199,8 @@ void CTrashView::MessageReceived( BMessage *msg )
 			Invalidate(  );
 			break;
 		case B_SIMPLE_DATA :
-			if( msg->FindInt32( "slot" ) )
+			int32 num;
+			if( msg->FindInt32( "slot", &num ) == B_OK )
 				msg->SendReply( new BMessage( '8dcl' ) );
 			else
 				MoveToTrash( msg ); 


### PR DESCRIPTION
Fixes #7 
If the top-most item was being deleted (so, it has a slot index of 0) , the if statement would evaluate to false, and the item would not be deleted.